### PR TITLE
Bug cache:clear : problem scope

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,29 +1,30 @@
 {
-    "name": "coresphere/console-bundle",
+    "name":        "winzou/console-bundle",
     "description": "This bundle allows you accessing the symfony2 console via your browser",
-    "keywords": ["console","javascript","symfony"],
-    "type": "symfony-bundle",
-    "license": "MIT",
+    "keywords":    ["console","javascript","symfony"],
+    "type":        "symfony-bundle",
+    "license":     "MIT",
     "authors": [
         {
-            "name": "Laszlo Korte",
+            "name":  "Laszlo Korte",
             "email": "coresphere@laszlokorte.de"
         },
         {
-            "name": "Marmus Ullman",
+            "name":  "Marmus Ullman",
             "email": "mail@markus-ullmann.de"
+        },
+        {
+            "name":     "Alexandre winzou Bacco",
+            "homepage": "http://www.tutoriel-symfony2.fr/"
         }
     ],
     "require": {
-        "php": ">=5.3.3",
-        "symfony/framework-bundle": ">=2.1.0,<3.0"
-    },
-    "require-dev": {
-        "symfony/console": ">=2.1.0,<3.0"
+        "php":                      ">=5.3.3",
+        "symfony/framework-bundle": ">=2.1.0,<3.0",
+        "symfony/console":          ">=2.1.0,<3.0"
     },
     "autoload": {
         "psr-0": { "CoreSphere\\ConsoleBundle": "" }
     },
-    "target-dir": "CoreSphere/ConsoleBundle",
-    "minimum-stability": "dev"
+    "target-dir": "CoreSphere/ConsoleBundle"
 }

--- a/readme.md
+++ b/readme.md
@@ -14,12 +14,12 @@ Features
 Installation
 ------------
 
- 1. Add ```coresphere/console-bundle``` to your composer.json file and run ```composer.phar install```
+ 1. Add ```coresphere/console-bundle``` to your composer.json file and run ```composer.phar update```
 
         // composer.json
         "require": {
             ...
-            "coresphere/console-bundle": "dev-master",
+            "winzou/console-bundle": "dev-master",
             ...
         }
 

--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ Installation
         // composer.json
         "require": {
             ...
-            "winzou/console-bundle": "dev-master",
+            "winzou/console-bundle": "1.*",
             ...
         }
 


### PR DESCRIPTION
Salut,
bug de scope lors d'un cache:clear :
Clearing the cache for the local environment with debug true
[Symfony\Component\DependencyInjection\Exception\InactiveScopeException]
You cannot create a service ("request") of an inactive scope ("request").
cache:clear [--no-warmup] [--no-optional-warmers]

Merci :)

------------

Hello,
bug when use cache:clear :
Clearing the cache for the local environment with debug true
[Symfony\Component\DependencyInjection\Exception\InactiveScopeException]
You cannot create a service ("request") of an inactive scope ("request").
cache:clear [--no-warmup] [--no-optional-warmers]

Thanks :)
