### PR TITLE
DEPRECATED Pattern in Route

### DIFF
--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -1,12 +1,12 @@
 console:
-    pattern:  /
+    path:  /
     defaults: { _controller: CoreSphereConsoleBundle:Console:console }
     requirements:
         _method: GET
 
 
 console_exec:
-    pattern:  /commands.{_format}
+    path:  /commands.{_format}
     defaults: { _controller: CoreSphereConsoleBundle:Console:exec, _format: json }
     requirements:
         _method: POST


### PR DESCRIPTION
DEPRECATED - The "pattern" option is deprecated. Use the "path" option in the route definition instead. #33