### PR TITLE
DEPRECATED "_method" requirement. Use the setMethods() method.

### DIFF
--- a/Resources/config/routing.yml
+++ b/Resources/config/routing.yml
@@ -1,13 +1,12 @@
 console:
     path:  /
     defaults: { _controller: CoreSphereConsoleBundle:Console:console }
-    requirements:
-        _method: GET
+    methods: [GET]
 
 
 console_exec:
     path:  /commands.{_format}
     defaults: { _controller: CoreSphereConsoleBundle:Console:exec, _format: json }
+    methods: [POST]
     requirements:
-        _method: POST
         _format: json


### PR DESCRIPTION
DEPRECATED - The "_method" requirement is deprecated since version 2.2 and will be removed in 3.0. Use the setMethods() method instead or the "methods" option in the route definition.  -

````
Called from Route::sanitizeRequirement() at line 535
Called from Route::addRequirements() at line 520
Called from Route::setRequirements() at line 91
Called from Route::__construct() at line 130
Called from YamlFileLoader::parseRoute() at line 95
Called from YamlFileLoader::load() at line 107
Called from FileLoader::import() at line 157
Called from YamlFileLoader::parseImport() at line 93
Called from YamlFileLoader::load() at line 107
Called from FileLoader::import() at line 157
Called from YamlFileLoader::parseImport() at line 93
Called from YamlFileLoader::load() at line 45
Called from DelegatingLoader::load() at line 76
Called from DelegatingLoader::load() at line 1572
Called from Router::getRouteCollection() at line 1353
Called from Router::getMatcherDumperInstance() at line 1303
Called from Router::Symfony\Component\Routing\{closure}()
Called from call_user_func() at line 46
Called from ConfigCacheFactory::cache() at line 1313
Called from Router::getMatcher() at line 1277
Called from Router::matchRequest() at line 2045
Called from RouterListener::onKernelRequest()
Called from call_user_func() at line 61
Called from WrappedListener::__invoke()
Called from call_user_func() at line 1826
Called from EventDispatcher::doDispatch() at line 1759
Called from EventDispatcher::dispatch() at line 1920
Called from ContainerAwareEventDispatcher::dispatch() at line 124
Called from TraceableEventDispatcher::dispatch() at line 3083
Called from HttpKernel::handleRaw() at line 3056
Called from HttpKernel::handle() at line 3207
Called from ContainerAwareHttpKernel::handle() at line 2429
Called from Kernel::handle() at line 28
````