### PR TITLE
composer: drop unused options

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,5 @@
     },
     "autoload": {
         "psr-0": { "CoreSphere\\ConsoleBundle": "" }
-    },
-    "target-dir": "CoreSphere/ConsoleBundle",
-    "minimum-stability": "dev"
+    }
 }


### PR DESCRIPTION
- there are `dev` packages used
- path can be managed by composer