### PR TITLE
CommandExecuter: getBuffer is sufficient

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,0 +1,17 @@
+before_commands:
+    - "composer install --prefer-source"
+
+tools:
+    external_code_coverage:
+        timeout: 900
+    sensiolabs_security_checker: true
+    php_code_coverage:
+        enabled: true
+    php_analyzer:
+        config:
+            verify_php_doc_comments:
+                suggest_more_specific_types: false
+
+checks:
+    php:
+        code_rating: true

--- a/Executer/CommandExecuter.php
+++ b/Executer/CommandExecuter.php
@@ -51,10 +51,7 @@ final class CommandExecuter implements CommandExecuterInterface
         $output->setFormatter(new HtmlOutputFormatterDecorator($formatter));
         $application->setAutoExit(false);
 
-        ob_start();
         $errorCode = $application->run($input, $output);
-        $result = $output->getBuffer() || ob_get_contents();
-        ob_end_clean();
 
         return [
             'input'       => $commandString,

--- a/README.md
+++ b/README.md
@@ -75,10 +75,3 @@ Tested with:
  * Firefox 4
  * Opera 11
  * Safari 5
-
-Todo
-----
-
- * Write Javascript tests
- * Add console as "pop up" to web developer toolbar
- * Figure out how to allow interactive mode (possible? extreme hacky?)


### PR DESCRIPTION
Works great.

Ref: https://github.com/CoreSphere/ConsoleBundle/pull/45#discussion_r38015502

---

Ready to merge, test should pass after `.scrutinizer.yml` is recognized on master.