### PR TITLE
Update services.yml

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -5,7 +5,7 @@ services:
             - "@templating"
             - "@coresphere_console.executer"
             - "@coresphere_console.application"
-            - %kernel.environment%
+            - "%kernel.environment%"
 
     coresphere_console.executer:
         class: CoreSphere\ConsoleBundle\Executer\CommandExecuter


### PR DESCRIPTION
Generate deprecation notice in PhpUnit "Not quoting a scalar starting with the "%" indicator character is deprecated since Symfony 3.1"