### PR TITLE
Do not format output if isDecorated is disabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_script:
 
 script:
   - phpunit $PHPUNIT_FLAGS
-  - if [[ $TRAVIS_PHP_VERSION = '5.6' ]]; then php php-cs-fixer fix . --diff --dry-run -v --level=psr2; fi
+  - if [[ $TRAVIS_PHP_VERSION = '5.6' ]]; then php php-cs-fixer fix . --diff --dry-run -v --rules=@Symfony; fi
 
 after_script:
   - if [[ $TRAVIS_PHP_VERSION = '5.6' ]]; then wget https://scrutinizer-ci.com/ocular.phar && php ocular.phar code-coverage:upload --format=php-clover coverage.xml; fi

--- a/Console/ApplicationFactory.php
+++ b/Console/ApplicationFactory.php
@@ -24,6 +24,7 @@ class ApplicationFactory
     {
         $application = new Application($kernel);
         $application = $this->registerCommandsToApplication($application, $kernel);
+
         return $application;
     }
 

--- a/Contract/Executer/CommandExecuterInterface.php
+++ b/Contract/Executer/CommandExecuterInterface.php
@@ -18,6 +18,7 @@ interface CommandExecuterInterface
 {
     /**
      * @param string $commandString
+     *
      * @return array
      */
     public function execute($commandString);

--- a/DependencyInjection/Extension/CoreSphereConsoleExtension.php
+++ b/DependencyInjection/Extension/CoreSphereConsoleExtension.php
@@ -35,7 +35,7 @@ final class CoreSphereConsoleExtension extends Extension implements PrependExten
     {
         $containerBuilder->prependExtensionConfig($this->getAlias(), [
             'resource' => '.',
-            'type' => 'extra'
+            'type' => 'extra',
         ]);
     }
 }

--- a/Executer/CommandExecuter.php
+++ b/Executer/CommandExecuter.php
@@ -54,10 +54,10 @@ final class CommandExecuter implements CommandExecuterInterface
         $errorCode = $application->run($input, $output);
 
         return [
-            'input'       => $commandString,
-            'output'      => $output->getBuffer(),
+            'input' => $commandString,
+            'output' => $output->getBuffer(),
             'environment' => $kernel->getEnvironment(),
-            'error_code'  => $errorCode
+            'error_code' => $errorCode,
         ];
     }
 
@@ -67,6 +67,7 @@ final class CommandExecuter implements CommandExecuterInterface
     private function getApplication(InputInterface $input)
     {
         $kernel = $this->getKernel($input);
+
         return new FrameworkConsoleApplication($kernel);
     }
 
@@ -83,6 +84,7 @@ final class CommandExecuter implements CommandExecuterInterface
         }
 
         $kernelClass = new ReflectionClass($this->baseKernel);
+
         return $kernelClass->newInstance($env, $debug);
     }
 }

--- a/Formatter/HtmlOutputFormatterDecorator.php
+++ b/Formatter/HtmlOutputFormatterDecorator.php
@@ -22,32 +22,31 @@ final class HtmlOutputFormatterDecorator implements OutputFormatterInterface
      * @var string[]
      */
     private $styles = [
-        '30'    => 'color:rgba(0,0,0,1)',
-        '31'    => 'color:rgba(230,50,50,1)',
-        '32'    => 'color:rgba(50,230,50,1)',
-        '33'    => 'color:rgba(230,230,50,1)',
-        '34'    => 'color:rgba(50,50,230,1)',
-        '35'    => 'color:rgba(230,50,150,1)',
-        '36'    => 'color:rgba(50,230,230,1)',
-        '37'    => 'color:rgba(250,250,250,1)',
-        '40'    => 'color:rgba(0,0,0,1)',
-        '41'    => 'background-color:rgba(230,50,50,1)',
-        '42'    => 'background-color:rgba(50,230,50,1)',
-        '43'    => 'background-color:rgba(230,230,50,1)',
-        '44'    => 'background-color:rgba(50,50,230,1)',
-        '45'    => 'background-color:rgba(230,50,150,1)',
-        '46'    => 'background-color:rgba(50,230,230,1)',
-        '47'    => 'background-color:rgba(250,250,250,1)',
-        '1'     => 'font-weight:bold',
-        '4'     => 'text-decoration:underline',
-        '8'     => 'visibility:hidden',
+        '30' => 'color:rgba(0,0,0,1)',
+        '31' => 'color:rgba(230,50,50,1)',
+        '32' => 'color:rgba(50,230,50,1)',
+        '33' => 'color:rgba(230,230,50,1)',
+        '34' => 'color:rgba(50,50,230,1)',
+        '35' => 'color:rgba(230,50,150,1)',
+        '36' => 'color:rgba(50,230,230,1)',
+        '37' => 'color:rgba(250,250,250,1)',
+        '40' => 'color:rgba(0,0,0,1)',
+        '41' => 'background-color:rgba(230,50,50,1)',
+        '42' => 'background-color:rgba(50,230,50,1)',
+        '43' => 'background-color:rgba(230,230,50,1)',
+        '44' => 'background-color:rgba(50,50,230,1)',
+        '45' => 'background-color:rgba(230,50,150,1)',
+        '46' => 'background-color:rgba(50,230,230,1)',
+        '47' => 'background-color:rgba(250,250,250,1)',
+        '1' => 'font-weight:bold',
+        '4' => 'text-decoration:underline',
+        '8' => 'visibility:hidden',
     ];
 
     /**
      * @var OutputFormatterInterface
      */
     private $formatter;
-
 
     public function __construct(OutputFormatterInterface $formatter)
     {
@@ -99,7 +98,7 @@ final class HtmlOutputFormatterDecorator implements OutputFormatterInterface
      */
     public function format($message)
     {
-        if(!$this->isDecorated()) {
+        if (!$this->isDecorated()) {
             return $message;
         }
         $formatted = $this->formatter->format($message);
@@ -107,6 +106,7 @@ final class HtmlOutputFormatterDecorator implements OutputFormatterInterface
         $converted = preg_replace_callback(self::CLI_COLORS_PATTERN, function ($matches) {
             return $this->replaceFormat($matches);
         }, $escaped);
+
         return $converted;
     }
 
@@ -117,7 +117,7 @@ final class HtmlOutputFormatterDecorator implements OutputFormatterInterface
     {
         $text = $matches[3];
         $styles = explode(';', $matches[1]);
-        
+
         $css = array_intersect_key($this->styles, array_flip($styles));
 
         return sprintf(

--- a/Formatter/HtmlOutputFormatterDecorator.php
+++ b/Formatter/HtmlOutputFormatterDecorator.php
@@ -99,6 +99,9 @@ final class HtmlOutputFormatterDecorator implements OutputFormatterInterface
      */
     public function format($message)
     {
+        if(!$this->isDecorated()) {
+            return $message;
+        }
         $formatted = $this->formatter->format($message);
         $escaped = htmlspecialchars($formatted, ENT_QUOTES, 'UTF-8');
         $converted = preg_replace_callback(self::CLI_COLORS_PATTERN, function ($matches) {

--- a/Output/StringOutput.php
+++ b/Output/StringOutput.php
@@ -28,7 +28,7 @@ class StringOutput extends Output
      */
     public function doWrite($message, $newline)
     {
-        $this->buffer .= $message . (true === $newline ? PHP_EOL : '');
+        $this->buffer .= $message.(true === $newline ? PHP_EOL : '');
     }
 
     /**

--- a/Routing/Loader.php
+++ b/Routing/Loader.php
@@ -35,8 +35,9 @@ final class Loader implements LoaderInterface
     {
         $collection = new RouteCollection();
         $collection->addCollection(
-            $this->yamlFileLoader->import(__DIR__ . '/../Resources/config/routing.yml')
+            $this->yamlFileLoader->import(__DIR__.'/../Resources/config/routing.yml')
         );
+
         return $collection;
     }
 

--- a/Tests/Console/ApplicationFactoryTest.php
+++ b/Tests/Console/ApplicationFactoryTest.php
@@ -30,8 +30,9 @@ final class ApplicationFactoryTest extends PHPUnit_Framework_TestCase
 
     /**
      * @dataProvider provideTestCommandRegistration()
+     *
      * @param string $environment
-     * @param int $commandCount
+     * @param int    $commandCount
      */
     public function testCommandsRegistration($environment, $commandCount)
     {
@@ -50,7 +51,7 @@ final class ApplicationFactoryTest extends PHPUnit_Framework_TestCase
         return [
             ['prod', 9],
             ['dev', 3],
-            ['test', 2]
+            ['test', 2],
         ];
     }
 

--- a/Tests/Controller/ConsoleControllerTest.php
+++ b/Tests/Controller/ConsoleControllerTest.php
@@ -65,11 +65,12 @@ final class ConsoleControllerTest extends PHPUnit_Framework_TestCase
         $this->assertSame([
             [
                 'output' => 'help-output',
-                'error_code' => 0
-            ], [
+                'error_code' => 0,
+            ],
+            [
                 'output' => 'list-output',
-                'error_code' => 0
-            ]
+                'error_code' => 0,
+            ],
         ], $commandsOutput);
     }
 
@@ -80,12 +81,13 @@ final class ConsoleControllerTest extends PHPUnit_Framework_TestCase
         $controller->execAction($request);
 
         $this->assertSame([[
-            'error_code' => 1
+            'error_code' => 1,
         ]], $this->renderArguments[1]['commands']);
     }
 
     /**
      * @param string $environment
+     *
      * @return ConsoleController
      */
     private function createControllerWithEnvironment($environment)
@@ -102,7 +104,6 @@ final class ConsoleControllerTest extends PHPUnit_Framework_TestCase
         );
     }
 
-
     /**
      * @return ObjectProphecy
      */
@@ -115,6 +116,7 @@ final class ConsoleControllerTest extends PHPUnit_Framework_TestCase
                 $that->renderArguments = $args;
             }
         );
+
         return $templatingMock;
     }
 
@@ -126,29 +128,32 @@ final class ConsoleControllerTest extends PHPUnit_Framework_TestCase
         $commandExecuterMock = $this->prophesize(CommandExecuterInterface::class);
         $commandExecuterMock->execute(Argument::exact('error-command'))
             ->willReturn([
-                'error_code' => 1
+                'error_code' => 1,
             ]);
         $commandExecuterMock->execute(Argument::exact('help'))
             ->willReturn([
                 'output' => 'help-output',
-                'error_code' => 0
+                'error_code' => 0,
             ]);
         $commandExecuterMock->execute(Argument::exact('list'))
             ->willReturn([
                 'output' => 'list-output',
-                'error_code' => 0
+                'error_code' => 0,
             ]);
+
         return $commandExecuterMock;
     }
 
     /**
      * @param string $environment
+     *
      * @return Application
      */
     private function createApplicationWithEnvironment($environment)
     {
         $kernel = new KernelWithBundlesWithCommands($environment, true);
         $application = (new ApplicationFactory())->create($kernel);
+
         return $application;
     }
 }

--- a/Tests/DependencyInjection/Extension/CoreSphereConsoleExtensionTest.php
+++ b/Tests/DependencyInjection/Extension/CoreSphereConsoleExtensionTest.php
@@ -41,7 +41,7 @@ final class CoreSphereConsoleExtensionTest extends PHPUnit_Framework_TestCase
         $extensionConfig = $containerBuilder->getExtensionConfig($extension->getAlias());
         $this->assertSame([
             'resource' => '.',
-            'type' => 'extra'
+            'type' => 'extra',
         ], $extensionConfig[0]);
     }
 
@@ -53,6 +53,7 @@ final class CoreSphereConsoleExtensionTest extends PHPUnit_Framework_TestCase
         $containerBuilder = new ContainerBuilder();
         $containerBuilder->setDefinition('kernel', new Definition(SomeKernel::class))
             ->setArguments(['prod', true]);
+
         return $containerBuilder;
     }
 }

--- a/Tests/Executer/CommandExecuterTest.php
+++ b/Tests/Executer/CommandExecuterTest.php
@@ -27,7 +27,7 @@ class CommandExecuterTest extends PHPUnit_Framework_TestCase
         $this->assertSame('prod', $result['environment']);
         $this->assertSame(0, $result['error_code']);
     }
-    
+
     public function testExecuteWithExplicitEnvironment()
     {
         $executer = $this->createExecuterWithKernel('prod', true);
@@ -52,12 +52,14 @@ class CommandExecuterTest extends PHPUnit_Framework_TestCase
 
     /**
      * @param string $env
-     * @param bool $debug
+     * @param bool   $debug
+     *
      * @return CommandExecuter
      */
     private function createExecuterWithKernel($env, $debug)
     {
         $kernel = new SomeKernel($env, $debug);
+
         return new CommandExecuter($kernel);
     }
 }

--- a/Tests/Executer/CommandExecutorSource/SomeKernel.php
+++ b/Tests/Executer/CommandExecutorSource/SomeKernel.php
@@ -24,7 +24,7 @@ final class SomeKernel extends Kernel
     public function registerBundles()
     {
         return [
-            new FrameworkBundle()
+            new FrameworkBundle(),
         ];
     }
 
@@ -43,7 +43,7 @@ final class SomeKernel extends Kernel
      */
     public function getCacheDir()
     {
-        return sys_get_temp_dir() . '/_console_tests/temp';
+        return sys_get_temp_dir().'/_console_tests/temp';
     }
 
     /**
@@ -51,6 +51,6 @@ final class SomeKernel extends Kernel
      */
     public function getLogDir()
     {
-        return sys_get_temp_dir() . '/_console_tests/log';
+        return sys_get_temp_dir().'/_console_tests/log';
     }
 }

--- a/Tests/Formatter/HtmlOutputFormatterDecoratorTest.php
+++ b/Tests/Formatter/HtmlOutputFormatterDecoratorTest.php
@@ -28,12 +28,11 @@ final class HtmlOutputFormatterDecoratorTest extends PHPUnit_Framework_TestCase
         $this->decoratedFormatter = new HtmlOutputFormatterDecorator(new OutputFormatter(true));
     }
 
-
     public function testEscapingOutput()
     {
-        $this->decoratedFormatter->setStyle('error',    new OutputFormatterStyle('white', 'red'));
-        $this->decoratedFormatter->setStyle('info',     new OutputFormatterStyle('green'));
-        $this->decoratedFormatter->setStyle('comment',  new OutputFormatterStyle('yellow'));
+        $this->decoratedFormatter->setStyle('error', new OutputFormatterStyle('white', 'red'));
+        $this->decoratedFormatter->setStyle('info', new OutputFormatterStyle('green'));
+        $this->decoratedFormatter->setStyle('comment', new OutputFormatterStyle('yellow'));
         $this->decoratedFormatter->setStyle('question', new OutputFormatterStyle('black', 'cyan'));
 
         $this->assertSame(

--- a/Tests/Formatter/HtmlOutputFormatterDecoratorTest.php
+++ b/Tests/Formatter/HtmlOutputFormatterDecoratorTest.php
@@ -74,6 +74,20 @@ final class HtmlOutputFormatterDecoratorTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($this->decoratedFormatter->isDecorated());
     }
 
+    public function testUndecorated()
+    {
+        $this->decoratedFormatter->setStyle('info', new OutputFormatterStyle('green'));
+
+        $this->decoratedFormatter->setDecorated(false);
+
+        $this->assertSame(
+            '<info>Do not change</info>',
+            $this->decoratedFormatter->format(
+                '<info>Do not change</info>'
+            )
+        );
+    }
+
     public function testStyle()
     {
         $this->assertFalse($this->decoratedFormatter->hasStyle('nonExisting'));

--- a/Tests/Output/StringOutputTest.php
+++ b/Tests/Output/StringOutputTest.php
@@ -26,6 +26,6 @@ final class StringOutputTest extends PHPUnit_Framework_TestCase
         $this->assertSame($text, $output->getBuffer());
 
         $output->write($text, true);
-        $this->assertSame($text . $text . PHP_EOL, $output->getBuffer());
+        $this->assertSame($text.$text.PHP_EOL, $output->getBuffer());
     }
 }

--- a/Tests/Source/KernelWithBundlesWithCommands.php
+++ b/Tests/Source/KernelWithBundlesWithCommands.php
@@ -48,7 +48,7 @@ final class KernelWithBundlesWithCommands extends Kernel
      */
     public function getCacheDir()
     {
-        return sys_get_temp_dir() . '/_console_tests/temp';
+        return sys_get_temp_dir().'/_console_tests/temp';
     }
 
     /**
@@ -56,6 +56,6 @@ final class KernelWithBundlesWithCommands extends Kernel
      */
     public function getLogDir()
     {
-        return sys_get_temp_dir() . '/_console_tests/log';
+        return sys_get_temp_dir().'/_console_tests/log';
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
         "doctrine/doctrine-fixtures-bundle": "^2.2",
         "doctrine/doctrine-migrations-bundle": "^1.0",
         "phpunit/phpunit": "^4.8",
-        "symfony/finder": "^2.7"
+        "symfony/finder": "^2.7",
+        "symfony/templating": "^3.2"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
fixes #73 

The problem is that the SymfonyStyle class calculates the output string length with all formatting modifiers stripped. But if the string already contained formatting modifiers that we convert to html elements even if `setDecorated(false)` has been called the string will get longer that. causing the second parameter to `str_repeat` to be negative.