### PR TITLE
Remove tests files from autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,10 @@
     },
     "autoload": {
         "psr-4": {
-            "CoreSphere\\ConsoleBundle\\": "."
-        }
+            "CoreSphere\\ConsoleBundle\\": ""
+        },
+        "exclude-from-classmap": [
+            "Tests/"
+        ]
     }
 }


### PR DESCRIPTION
Tests files should not be loaded outside the development scope.