### PR TITLE
Update DataCollector.php

### DIFF
--- a/DataCollector/DataCollector.php
+++ b/DataCollector/DataCollector.php
@@ -39,5 +39,4 @@ final class DataCollector extends DataCollectorBase
     {
         $this->data = [];
     }
-    
 }

--- a/DataCollector/DataCollector.php
+++ b/DataCollector/DataCollector.php
@@ -31,4 +31,13 @@ final class DataCollector extends DataCollectorBase
     {
         return 'coresphere_console';
     }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function reset()
+    {
+        $this->data = [];
+    }
+    
 }


### PR DESCRIPTION
sf 3.4 + & 4+

(1/1) FatalErrorException
Error: Class CoreSphere\ConsoleBundle\DataCollector\DataCollector contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Symfony\Component\HttpKernel\DataCollector\DataCollectorInterface::reset)