### PR TITLE
Add the missing reset() method

### DIFF
--- a/DataCollector/DataCollector.php
+++ b/DataCollector/DataCollector.php
@@ -27,6 +27,13 @@ final class DataCollector extends DataCollectorBase
     /**
      * {@inheritdoc}
      */
+    public function reset()
+    {
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function getName()
     {
         return 'coresphere_console';


### PR DESCRIPTION
Add reset() method to remove Symfony 3.4 deprecation and allow compatibility with Symfony > 4