### PR TITLE
Update DataCollector.php

### DIFF
--- a/DataCollector/DataCollector.php
+++ b/DataCollector/DataCollector.php
@@ -31,4 +31,8 @@ final class DataCollector extends DataCollectorBase
     {
         return 'coresphere_console';
     }
+    
+    public function reset() { 
+        return parent::reset(); 
+    }
 }


### PR DESCRIPTION
fix problem -  Class CoreSphere\ConsoleBundle\DataCollector\DataCollector contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (Symfony\Contracts\Service\ResetInterface::reset)